### PR TITLE
Simplify CI setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,27 +6,22 @@ on:
 
 jobs:
   mypy:
+    timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - run: pip install mypy==1.8.0
-    - run: |
-        mypy --platform linux --python-version 3.10 config.py
-        mypy --platform linux --python-version 3.11 config.py
-        mypy --platform linux --python-version 3.12 config.py
+    - run: mypy config.py
 
   tests:
-    timeout-minutes: 5
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+    timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
     - run: python3 tests.py


### PR DESCRIPTION
- Do not mess with python versions, just use the same one I have locally.
- Update actions/checkout to fix a depreciation warning.